### PR TITLE
Corrected the spelling of deployment

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,5 @@
 name: Tomondre's portfolio webpage
-run-name: CI & CD worfklows for the Kubernetes deplyment 🚀
+run-name: CI & CD worfklows for the Kubernetes deployment 🚀
 on: [push]
 jobs:
   CI:


### PR DESCRIPTION
While going through the workflows folder, I came across that the world deployment was missing the letter o, so added it. 